### PR TITLE
Fixed failed to bind to address already in use

### DIFF
--- a/Itminus.InDirectLine.Web/Properties/launchSettings.json
+++ b/Itminus.InDirectLine.Web/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:3001;http://localhost:3000"
     }
   }
 }


### PR DESCRIPTION
When running the sample project with the command:
```sh
dotnet run -c Release
```
The following error is generated:
```
Failed to bind to address http://127.0.0.1:5000: address already in use.
```